### PR TITLE
Added the ability for the server to answer questions

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -82,7 +82,7 @@ mm/day = pixel_value / 4.0 # FLOAT!
 It is possible to ask the server for available data. To do this, send a GET or POST request to:
 
 ```
-/api/<variable>
+/api/question
 ```
 
 This will return a json with something like this: 

--- a/doc/API.md
+++ b/doc/API.md
@@ -7,7 +7,7 @@ This document outlines the Thor Web API.
 The URL-scheme are as follows:
 
 ```
-/api/variable
+/api/<variable>
 ```
 
 Returned data variable and dimensionality is decided by in-arguments given by the client. 
@@ -71,17 +71,48 @@ celcius = (pixel_value - 128) / 2.0 # FLOAT!
 
 ### Percipitation
 
-Percipitation returned as a PNG image is clamped to 0-255 integer range since limited by PNG integer range. The total percipitation range is 0 to 62 mm/day. This means that each step in the PNG integer range represents 0,25 mm/day of rain. Formula for getting percipitation in Celcius from a pixel value in returned image is as follows.
+Percipitation returned as a PNG image is clamped to 0-255 integer range since limited by PNG integer range. The total precipitation range is 0 to 62 mm/day. This means that each step in the PNG integer range represents 0,25 mm/day of rain. Formula for getting precipitation in Celcius from a pixel value in returned image is as follows.
 
 ```
 mm/day = pixel_value / 4.0 # FLOAT!
 ```
 
+## Finding available climate models
 
-For more specific information on each function, please see the respective functions:
+It is possible to ask the server for available data. To do this, send a GET or POST request to:
 
-- [temperature](temperature.md)
-- [air-pressure](air-pressure.md)
-- [precipitation](precipitation.md)
-- [water-level](water-level.md)
+```
+/api/<variable>
+```
+
+This will return a json with something like this: 
+
+```
+{
+	"exhaust-levels": [
+		"rcp45",
+		"rcp85"
+	],
+	"models": [
+		"ICHEC-EC-EARTH",
+		"CNRM-CERFACS-CNRM-CM5",
+		"IPSL-IPSL-CM5A-MR"
+	],
+	"ok": true,
+	"domains": [
+		"NAM-44i",
+		"CAM-44i",
+		"EUR-11i",
+		"WAS-44i",
+		"EUR-44i",
+		"MNA-22i",
+		"AFR-44i",
+		"SAM-44i",
+		"ARC-44i",
+		"MNA-44i"
+	]
+}
+```
+
+It is also possible for the server to return the entire internal tree structure of the server by setting the argument "with-tree". This is however very taxing for the server and will give a much longer response time (seconds!). 
 

--- a/thor.py
+++ b/thor.py
@@ -46,6 +46,7 @@ if __name__ == "__main__":
         const.log.addHandler(fileHandler)
 
     # Load ncFiles
+    const.ncFolder = ncFolder
     const.ncFiles = frozendict.FrozenDict(util.openFiles(ncFolder))
     if printTree:
         util.printTree(ncFolder)

--- a/thor/request.py
+++ b/thor/request.py
@@ -7,6 +7,30 @@ from datetime import timedelta
 import numpy as np
 import logging
 from math import floor
+import thor.util as util
+
+
+def getClimateModels(ncFileTree, arguments, ncFolder):
+    returnData = {}
+    returnData["domains"] = []
+    returnData["models"] = []
+    returnData["exhaust-levels"] = []
+
+    for domain, modelDict in ncFileTree.items():
+        if domain not in returnData["domains"]:
+            returnData["domains"].append(domain)
+        for model, experimentDict in modelDict.items():
+            if model not in returnData["models"]:
+                returnData["models"].append(model)
+            for experiment in experimentDict.keys():
+                if experiment not in returnData["exhaust-levels"]:
+                    returnData["exhaust-levels"].append(experiment)
+
+    if arguments["with-tree"]:
+        returnData["tree"] = util.getTreeAsString(ncFolder)
+
+    returnData["ok"] = True
+    return returnData
 
 
 def getReaderList(dictTree,

--- a/thor/routes.py
+++ b/thor/routes.py
@@ -24,7 +24,7 @@ def hello_world():
 
 
 @thorApp.route('/api/question', methods=["GET", "POST"])
-def quistion():
+def question():
     # None if args not given as json
     arguments = flask.request.get_json()
     # Set arguments from URL if not from json

--- a/thor/routes.py
+++ b/thor/routes.py
@@ -23,6 +23,23 @@ def hello_world():
             code=302)
 
 
+@thorApp.route('/api/question', methods=["GET", "POST"])
+def quistion():
+    # None if args not given as json
+    arguments = flask.request.get_json()
+    # Set arguments from URL if not from json
+    if arguments is None:
+        arguments = flask.request.args.to_dict(flat=False)
+        # Some way every argument is nested in list
+        # Remove this somehow
+        for arg, value in arguments.items():
+            arguments[arg] = value[0]
+    if not "with-tree" in arguments:
+        arguments["with-tree"] = False
+    return json.dumps(request.getClimateModels(const.ncFiles, arguments, const.ncFolder))
+
+
+
 @thorApp.route('/api/<variable>', methods=["GET", "POST"])
 def api(variable):
     # None if args not given as json

--- a/thor/util.py
+++ b/thor/util.py
@@ -158,7 +158,7 @@ def argumentsHandler(arguments):
     return arguments
 
 
-def printTree(folder):
+def getTreeAsString(folder):
     domainDict = openFiles(folder)
     for domain, modelDict in domainDict.items():
         for model, expDict in modelDict.items():
@@ -170,8 +170,11 @@ def printTree(folder):
                                 + str(readerList[i].getStartDate())[0:10]\
                                 + " - "\
                                 + str(readerList[i].getLastDate())[0:10]
+    return domainDict
 
-    print(json.dumps(domainDict,
+
+def printTree(folder):
+    print(json.dumps(getTreeAsString(folder),
                      sort_keys=True,
                      indent=4,
                      separators=(',', ': ')))


### PR DESCRIPTION
It is possible to ask the server for available data. To do this, send a GET or POST request to:

```
/api/question
```

This will return a json with something like this: 

```
{
	"exhaust-levels": [
		"rcp45",
		"rcp85"
	],
	"models": [
		"ICHEC-EC-EARTH",
		"CNRM-CERFACS-CNRM-CM5",
		"IPSL-IPSL-CM5A-MR"
	],
	"ok": true,
	"domains": [
		"NAM-44i",
		"CAM-44i",
		"EUR-11i",
		"WAS-44i",
		"EUR-44i",
		"MNA-22i",
		"AFR-44i",
		"SAM-44i",
		"ARC-44i",
		"MNA-44i"
	]
}
```

It is also possible for the server to return the entire internal tree structure of the server by setting the argument "with-tree". This is however very taxing for the server and will give a much longer response time (seconds!). 