### PR TITLE
Stopped looping over unnecessary variable

### DIFF
--- a/scripts/populateCache.bash
+++ b/scripts/populateCache.bash
@@ -29,15 +29,13 @@ done
 
 # Historical as well
 for model in $models; do
-    for exhaustLevel in $exhaustLevels; do
-        for year in $(seq 1950 2005); do
-            for month in $(seq 1 12); do
-                curlString="http://thor.hfelo.se/api/temperature?to-latitude=90&month=$month&climate-model=$model&year=$year&height-resolution=$resolution&exhaust-level=historical&from-latitude=-90&from-longitude=-180&to-longitude=180" 
-                echo "Fetching: "
-                echo $curlString 
-                curl $curlString > /dev/null
-                echo ""
-            done
+    for year in $(seq 1950 2005); do
+        for month in $(seq 1 12); do
+            curlString="http://thor.hfelo.se/api/temperature?to-latitude=90&month=$month&climate-model=$model&year=$year&height-resolution=$resolution&exhaust-level=historical&from-latitude=-90&from-longitude=-180&to-longitude=180" 
+            echo "Fetching: "
+            echo $curlString 
+            curl $curlString > /dev/null
+            echo ""
         done
     done
 done


### PR DESCRIPTION
Exhaust levels are unnecessary to loop over when requesting historical. 